### PR TITLE
Remove AWS CLI dependency and reorganize code in functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 variables.tf.json
-variables.tf.json.new
 terraform.tfstate
 terraform.tfstate.backup
-

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Terraform module to get the AZs you have access to.
 
 Reads a set of accounts from ~/.aws/credentials and queries
-each region to find the AZs you can use in that region
+each region to find the AZs you can use in that region and that account.
 
-Needs the aws cli installed to shell out to.
+Needs the aws-sdk ruby client to generate the variables.tf.json file.
 
 Also needs you to run 'make' in the directory after _terraform get_ to build the lists.
 

--- a/getvariables.rb
+++ b/getvariables.rb
@@ -1,92 +1,117 @@
 #!/usr/bin/ruby
 require 'json'
+require 'aws-sdk'
 
-ENV.delete('AWS_ACCESS_KEY_ID')
-ENV.delete('AWS_SECRET_ACCESS_KEY')
-
-profiles = []
-File.open(File.expand_path('~/.aws/credentials'), 'r') do |f|
-  f.each_line do |l|
-    next unless l.gsub!(/^\[\s*(\w+)\s*\].*/, '\1')
-    l.chomp!
-    next if l == 'default'
-    profiles.push(l)
-  end
-end
-
-primary_azs = {}
-secondary_azs = {}
-tertiary_azs = {}
-az_counts = {}
-az_lists = {}
-az_letters = {}
-
-data = profiles.map do |account|
-  regions_json = `aws ec2 describe-regions --output json --profile #{account} --region us-east-1`
-  if $?.exitstatus != 0
-    print "Failed to run aws ec2 describe-regions --output json --profile #{account} --region us-east-1"
+def get_aws_profiles
+# Read all the available profile.
+# For safety reasons 'default' profile will be skipped.
+  begin
+    profiles = []
+    File.open(File.expand_path('~/.aws/credentials'), 'r') do |f|
+      f.each_line do |l|
+        next unless l.gsub!(/^\[\s*(\w+)\s*\].*/, '\1')
+        l.chomp!
+        next if l == 'default'
+        profiles.push(l)
+      end
+    end
+  rescue StandardError => e
+    puts e.message
     exit 1
   end
-  regions = JSON.parse(regions_json)['Regions'].map { |d| d['RegionName'] }
-  regions.map do |region|
-    azs_json = `aws ec2 describe-availability-zones --output json --profile #{account} --region #{region}`
-    if $?.exitstatus != 0
-      print "Failed to run aws ec2 describe-availability-zones --output json --profile #{account} --region #{region}"
-      exit 1
-    end
-    JSON.parse(azs_json)['AvailabilityZones'].map do |tuple|
-      tuple[:name] = "#{account}-#{tuple['RegionName']}"
-      tuple[:sortkey] = "#{account}-#{tuple['ZoneName']}"
-      tuple
-    end
-  end.flatten
-end.flatten.reject { |tuple| tuple['State'] != 'available' }.sort do |a,b|
-  a[:sortkey] <=> b[:sortkey]
+
+  profiles
 end
 
-data.each do |tuple|
-  az_counts[tuple[:name]] ||= 0
-  az_counts[tuple[:name]] = az_counts[tuple[:name]]+1
-  az_lists[tuple[:name]] ||= []
-  az_lists[tuple[:name]].push tuple['ZoneName']
-  az_letters[tuple[:name]] ||= []
-  az_letters[tuple[:name]].push tuple['ZoneName'][-1,1]
-  if !primary_azs[tuple[:name]]
-    primary_azs[tuple[:name]] = tuple['ZoneName']
-  elsif !secondary_azs[tuple[:name]]
-    secondary_azs[tuple[:name]] = tuple['ZoneName']
-  elsif !tertiary_azs[tuple[:name]]
-    tertiary_azs[tuple[:name]] = tuple['ZoneName']
+def get_AZs_by_profile account
+  credentials = Aws::SharedCredentials.new(profile_name: "#{account}")
+  @ec2 = Aws::EC2::Client.new(credentials: credentials, region: 'us-east-1')
+
+  begin
+    data = []
+    regions = @ec2.describe_regions().data.regions.map { |region| region.region_name}
+
+    regions.each do |region|
+      @ec2 = Aws::EC2::Client.new(credentials: credentials, region: "#{region}")
+      @ec2.describe_availability_zones({ filters: [{ name: 'state', values: ['available']}] }).data.availability_zones.map do |az|
+        data <<  { 'State' => az.state, 'RegionName' => az.region_name, 'ZoneName' => az.zone_name, :name => "#{account}-#{az.region_name}", :sortkey => "#{account}-#{az.zone_name}" }
+      end
+    end
+
+    # Sort the AZs by account
+    data.sort { |a,b| a[:sortkey] <=> b[:sortkey] }
+  rescue StandardError => e
+    puts e.message
+    exit 1
   end
 end
 
-[az_lists, az_letters].each do |squash|
-  squash.each_key { |k| squash[k] = squash[k].join ',' }
-end
-az_counts.each_key { |k| az_counts[k] = "#{az_counts[k]}" }
+def build_variables_file data
+  # Output variables
+  primary_azs = {}
+  secondary_azs = {}
+  tertiary_azs = {}
+  az_counts = {}
+  az_lists = {}
+  az_letters = {}
 
-output = {
- "variable" => {
-    "primary_azs" => {
-      "default" => primary_azs
-    },
-    'secondary_azs' => {
-       "default" => secondary_azs
-    },
-    'tertiary_azs' => {
-        "default" => tertiary_azs
-    },
-    'list_all' => {
-        'default' => az_lists
-    },
-    'list_letters' => {
-        'default' => az_letters
-    },
-    'az_counts' => {
-        'default' => az_counts
-    }
+  data.each do |tuple|
+    az_counts[tuple[:name]] ||= 0
+    az_counts[tuple[:name]] = az_counts[tuple[:name]]+1
+    az_lists[tuple[:name]] ||= []
+    az_lists[tuple[:name]].push tuple['ZoneName']
+    az_letters[tuple[:name]] ||= []
+    az_letters[tuple[:name]].push tuple['ZoneName'][-1,1]
+    if !primary_azs[tuple[:name]]
+      primary_azs[tuple[:name]] = tuple['ZoneName']
+    elsif !secondary_azs[tuple[:name]]
+      secondary_azs[tuple[:name]] = tuple['ZoneName']
+    elsif !tertiary_azs[tuple[:name]]
+      tertiary_azs[tuple[:name]] = tuple['ZoneName']
+    end
+  end
+
+  [az_lists, az_letters].each do |squash|
+    squash.each_key { |k| squash[k] = squash[k].join ',' }
+  end
+  az_counts.each_key { |k| az_counts[k] = "#{az_counts[k]}" }
+
+  output = {
+      "variable" => {
+          "primary_azs" => {
+              "default" => primary_azs
+          },
+          'secondary_azs' => {
+              "default" => secondary_azs
+          },
+          'tertiary_azs' => {
+              "default" => tertiary_azs
+          },
+          'list_all' => {
+              'default' => az_lists
+          },
+          'list_letters' => {
+              'default' => az_letters
+          },
+          'az_counts' => {
+              'default' => az_counts
+          }
+      }
   }
-}
 
-File.open('variables.tf.json.new', 'w') { |f| f.puts JSON.pretty_generate(output) }
-File.rename 'variables.tf.json.new', 'variables.tf.json'
+  begin
+    File.open('variables.tf.json.new', 'w') { |f| f.puts JSON.pretty_generate(output) }
+    File.rename 'variables.tf.json.new', 'variables.tf.json'
+  rescue StandardError => e
+    puts e.message
+    exit 1
+  end
+end
+
+# RUN RUN
+variables = []
+get_aws_profiles.each { |account| variables += get_AZs_by_profile account }
+build_variables_file variables
+
+
+


### PR DESCRIPTION
# Objectives
1. Remove aws cli dependency in getvariables.rb
2. Clarify the script organising the code in some functions
# Motivation

This PR **does not introduce any big or important improvement**, just change AWS CLI calls by aws-sdk ruby calls.
IMHO, this will fit better with a community module, keeping all the functionality in the ruby scope and having more flexibility than AWS CLI. 

Just reject the PR if you don't agree :)
# Changes
1. Remove AWS CLI dependency 
2. Organice the code in functions 
3. Remove the "clean of the environment variables", now the code is isolated.
4. Add more error controls
# Backward compatibility

The variables.tf.json file is exactly the same.
# Testing

Running getvariables.rb the json files is properly created.

```
# ruby getvariables.rb
```
