### PR TITLE
regex pattern change when reading profiles from ~/.aws/credentials

### DIFF
--- a/getvariables.rb
+++ b/getvariables.rb
@@ -38,7 +38,7 @@ profiles = []
 unless is_iam_instance?(options[:iam_profile_name])
   File.open(File.expand_path('~/.aws/credentials'), 'r') do |f|
     f.each_line do |l|
-      next unless l.gsub!(/^\[\s*(\w+)\s*\].*/, '\1')
+      next unless l.gsub!(/^\[\s*(.*?)\s*\].*/, '\1')
       l.chomp!
       profiles.push(l)
     end


### PR DESCRIPTION
[https://github.com/terraform-community-modules/tf_aws_availability_zones/issues/7]

regex pattern change when reading profiles from ~/.aws/credentials
